### PR TITLE
Optimize package installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ gradle-app.setting
 # gradle/wrapper/gradle-wrapper.properties
 
 .idea
+android-emulators-gradle.iml
+catrobat-gradle.iml
+local.properties
+android-emulators-gradle/android-emulators-gradle.iml

--- a/android-emulators-gradle/src/main/groovy/org/catrobat/gradle/androidemulators/EmulatorsPluginExtension.groovy
+++ b/android-emulators-gradle/src/main/groovy/org/catrobat/gradle/androidemulators/EmulatorsPluginExtension.groovy
@@ -116,7 +116,7 @@ class EmulatorsPluginExtension {
 
         // install necessary images if required
         if (this.performInstallation) {
-            installEmulator(e)
+            installEmulators()
         }
 
         e
@@ -164,8 +164,6 @@ class EmulatorsPluginExtension {
         this.performInstallation = performInstallation
         if (this.performInstallation) {
             installDependencies()
-            // If install = appears after emulators, retroactively install any emulators
-            //  we've already defined.
             installEmulators()
         }
     }
@@ -199,12 +197,11 @@ class EmulatorsPluginExtension {
     }
 
     private void installEmulators() {
-        emulatorLookup.forEach { k, v -> installEmulator(v as EmulatorExtension) }
-    }
-
-    private void installEmulator(EmulatorExtension emulator) {
         def installer = getInstaller()
         installer.writeLicenseFiles()
-        installer.installImage(emulator.avdSettings.systemImage)
+
+        emulatorLookup.each { k, v ->
+            installer.installImage(v.avdSettings.systemImage)
+        }
     }
 }

--- a/android-emulators-gradle/src/main/groovy/org/catrobat/gradle/androidemulators/Installer.groovy
+++ b/android-emulators-gradle/src/main/groovy/org/catrobat/gradle/androidemulators/Installer.groovy
@@ -32,6 +32,7 @@ import org.gradle.internal.impldep.org.apache.commons.lang.SystemUtils
 class Installer {
     File androidSdk
     SdkManager sdkManager
+    Set<String> installed = []
 
     Installer(File androidSdk = null) {
         if (androidSdk) {
@@ -89,8 +90,20 @@ class Installer {
             return this
         }
 
+        // Filter out packages that have already been installed this run
+        packages = packages.grep { !installed.contains(it) }
+
+        // If there's no work left, exit early
+        if(packages.empty) {
+            return this
+        }
+
         println("Installing packages [$packages] to [$androidSdk]")
         sdkManager.install(packages)
+
+        // Record packages as installed
+        installed.addAll(packages)
+
         this
     }
 


### PR DESCRIPTION
Optimize package installation by tracking which packages have been installed (during this run) and not attempting to reinstall them.  Quick way around the current n log n process.