### PR TITLE
JENKINS-329 remove logcat as filtering not working with current emulator

### DIFF
--- a/android-emulators-gradle/src/main/groovy/org/catrobat/gradle/androidemulators/EmulatorStarter.groovy
+++ b/android-emulators-gradle/src/main/groovy/org/catrobat/gradle/androidemulators/EmulatorStarter.groovy
@@ -50,7 +50,7 @@ class EmulatorStarter {
         emulator.addOptionalArguments(country, ['-prop', "persist.sys.country=$country"])
         emulator.addOptionalArguments(!showWindow, ['-no-window'])
         emulator.addOptionalArguments(!keepUserData, ['-wipe-data'])
-        emulator.addOptionalArguments(logcat, ['-logcat', '*:e', '-logcat-output', logcat.absolutePath])
+        emulator.addOptionalArguments(logcat, ['-logcat-output', logcat.absolutePath])
         emulator.addArguments(additionalParameters)
 
         emulator.environment(environment).verbose().executeAsynchronously()


### PR DESCRIPTION
Because of "emulator: WARNING: Logcat tag filtering is currently disabled. b/132840817, everything will be placed on stdout"
